### PR TITLE
fix deprecated information for mina 1.1.1 version

### DIFF
--- a/lib/mina/clockwork/tasks.rb
+++ b/lib/mina/clockwork/tasks.rb
@@ -26,21 +26,21 @@ set :clockworkd_full_cmd,  -> {
 namespace :clockwork do
   # mina clockwork:start
   desc "Start clockwork daemon"
-  task start: :remote_environment do
+  task :start do
     comment "Starting clockwork daemon"
     command "#{fetch(:clockworkd_full_cmd)} start"
   end
 
   # mina clockwork:stop
   desc "Stop clockwork daemon"
-  task stop: :remote_environment do
+  task :stop do
     comment "Stopping clockwork daemon"
     command "#{fetch(:clockworkd_full_cmd)} stop"
   end
 
   # mina clockwork:restart
   desc "Restart clockwork daemon"
-  task restart: :remote_environment do
+  task :restart do
     comment "Restarting clockwork daemon"
     command "#{fetch(:clockworkd_full_cmd)} restart"
   end

--- a/lib/mina/clockwork/tasks.rb
+++ b/lib/mina/clockwork/tasks.rb
@@ -26,21 +26,21 @@ set :clockworkd_full_cmd,  -> {
 namespace :clockwork do
   # mina clockwork:start
   desc "Start clockwork daemon"
-  task start: :environment do
+  task start: :remote_environment do
     comment "Starting clockwork daemon"
     command "#{fetch(:clockworkd_full_cmd)} start"
   end
 
   # mina clockwork:stop
   desc "Stop clockwork daemon"
-  task stop: :environment do
+  task stop: :remote_environment do
     comment "Stopping clockwork daemon"
     command "#{fetch(:clockworkd_full_cmd)} stop"
   end
 
   # mina clockwork:restart
   desc "Restart clockwork daemon"
-  task restart: :environment do
+  task restart: :remote_environment do
     comment "Restarting clockwork daemon"
     command "#{fetch(:clockworkd_full_cmd)} restart"
   end

--- a/mina-clockwork.gemspec
+++ b/mina-clockwork.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "clockwork"
-  spec.add_dependency "mina", ">= 1.0.2"
+  spec.add_dependency "mina", ">= 1.1.0"
 end


### PR DESCRIPTION
fix this deprecated message:

```
:environment is DEPRECATED! Please use local_environment and remote_environment
```